### PR TITLE
Screened *quote* character within field with no quotes.

### DIFF
--- a/csv.lisp
+++ b/csv.lisp
@@ -221,7 +221,8 @@
              (T (finish-item) (return items))))
 
           ;; the next characters are an escape sequence, start skipping
-          ((and (eql state :collecting-quoted)
+          ((and (or (eql state :collecting-quoted)
+                    (eql state :collecting))
                 *quote-escape* ;; if this is null there is no escape
                 (%escape-seq? line i *quote-escape* llen elen))
            (store-char *quote*)


### PR DESCRIPTION
I found CSV file, where fields were not quoted, but quote character was screened.
334-34-HH;Part-NO-334-34;GSM\'s module
This commit allows to parse such a file.
