### PR TITLE
Accept *quote* to be nil again.

### DIFF
--- a/parser.lisp
+++ b/parser.lisp
@@ -267,10 +267,13 @@ See: csv-reader "))
     #'vector
     (alexandria:flatten
      (list
-      (if (equal *escape-mode* :following)
-          (make-table-entry (vector *quote-escape* t) #'reading-escaped)
-          (make-table-entry (vector *quote* *quote*) #'reading-escaped))
-      (make-table-entry *quote* #'reading-quoted)
+      (when *quote*
+        (list
+         (if (equal *escape-mode* :following)
+             (make-table-entry (vector *quote-escape* t) #'reading-escaped)
+             (make-table-entry (vector *quote* *quote*) #'reading-escaped))
+         (make-table-entry *quote* #'reading-quoted)))
+
       (make-table-entry *separator* #'reading-separator)
 
       (if (member *read-newline* '(t nil) :test #'equalp)


### PR DESCRIPTION
It's possible to parse CSV files just fine where there's no quote in use,
and it used to be that CL-CSV would be fine with just a setting. Bring back
the old days where it just worked by simply omitting both the quote and the
escape quote when quote is nil.