### PR TITLE
Do not invoke 'map-fn' on the first line when 'skip-first-p' is true.

### DIFF
--- a/parser.lisp
+++ b/parser.lisp
@@ -229,13 +229,14 @@ See: csv-reader "))
   (let ((row (coerce (line-data csv-reader) 'list)))
     (setf (fill-pointer (line-data csv-reader)) 0)
     (setf row (csv-row-read row :csv-reader csv-reader))
-    (when map-fn
-      (setf row (funcall map-fn row)))
     (if (skip-row? csv-reader)
         (setf (skip-row? csv-reader) nil) ;; we skipped
-        (if row-fn
-            (funcall row-fn row)
-            (vector-push-extend row (rows csv-reader))))))
+        (progn
+          (when map-fn
+            (setf row (funcall map-fn row)))
+          (if row-fn
+              (funcall row-fn row)
+              (vector-push-extend row (rows csv-reader)))))))
 
 (defun drop-delimiter-chars (table entry)
   "This backs up the buffer till the delimiter is not in it


### PR DESCRIPTION
Currently, when `:skip-first-p` is true, `:map-fn` is invoked on the first
row and the results are thrown away. In the case where you want to use
the `map-fn` to convert the values to numbers, you will get an error on
the header row. This small patch changes the behavior such that the
`map-fn` is not invoked for the header row if `skip-first-p` is true.

I haven't been able to run the test suite on my machine, due to an
apparent incompatibility between `asdf` and `lisp-unit2`. I used the
following test case:

```
(defun test-map-fn-with-skip-first-p ()
  (let ((row-count 0))
    (cl-csv:read-csv
     (format nil "skip,header,row~%1,2,3~%")
     :map-fn (lambda (row) (setf row-count (1+ row-count))  row) :skip-first-p t)
    (assert (= row-count 1))))
```